### PR TITLE
Remove reference contents and update navigation links in Medicare dashboard

### DIFF
--- a/mmi-dashboard.md
+++ b/mmi-dashboard.md
@@ -45,12 +45,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
        '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
      [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
      [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
     '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -72,12 +72,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
        '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -195,12 +195,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -209,7 +209,7 @@ SELECT 'shell' AS component,
        '{"link":"/mmi/data-dictionary.sql","title":"Data Dictionary"}' AS menu_item;
 
 SELECT 'button' AS component, 'start' AS justify;
-SELECT 'Back' AS title, '/' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
+SELECT 'Back' AS title, '../' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
 
 SELECT 'hero' AS component,
     'Executive Dashboard' AS title,
@@ -307,12 +307,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -321,7 +321,7 @@ SELECT 'shell' AS component,
        '{"link":"/mmi/data-dictionary.sql","title":"Data Dictionary"}' AS menu_item;
 
 SELECT 'button' AS component, 'start' AS justify;
-SELECT 'Back' AS title, '/' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
+SELECT 'Back' AS title, '../' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
 
 SELECT 'hero' AS component,
     'Opportunity Scoring Engine' AS title,
@@ -379,12 +379,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -451,12 +451,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -465,7 +465,7 @@ SELECT 'shell' AS component,
        '{"link":"/mmi/data-dictionary.sql","title":"Data Dictionary"}' AS menu_item;
 
 SELECT 'button' AS component, 'start' AS justify;
-SELECT 'Back' AS title, '/' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
+SELECT 'Back' AS title, '../' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
 
 SELECT 'hero' AS component,
     'Disease Mapping' AS title,
@@ -546,12 +546,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -560,7 +560,7 @@ SELECT 'shell' AS component,
        '{"link":"/mmi/data-dictionary.sql","title":"Data Dictionary"}' AS menu_item;
 
 SELECT 'button' AS component, 'start' AS justify;
-SELECT 'Back' AS title, '/' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
+SELECT 'Back' AS title, '../' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
 
 SELECT 'hero' AS component,
     'Geographic Markets' AS title,
@@ -615,12 +615,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -629,7 +629,7 @@ SELECT 'shell' AS component,
        '{"link":"/mmi/data-dictionary.sql","title":"Data Dictionary"}' AS menu_item;
 
 SELECT 'button' AS component, 'start' AS justify;
-SELECT 'Back' AS title, '/' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
+SELECT 'Back' AS title, '../' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
 
 SELECT 'hero' AS component,
     'Procedure Drilldown' AS title,
@@ -732,12 +732,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -746,7 +746,7 @@ SELECT 'shell' AS component,
        '{"link":"/mmi/data-dictionary.sql","title":"Data Dictionary"}' AS menu_item;
 
 SELECT 'button' AS component, 'start' AS justify;
-SELECT 'Back' AS title, '/' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
+SELECT 'Back' AS title, '../' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
 
 SELECT 'hero' AS component,
     'Evidence & Market Prioritization' AS title,
@@ -1987,12 +1987,12 @@ SELECT 'shell' AS component,
        NULL AS icon,
        'fluid' AS layout,
        true AS fixed_top_menu,
-       '/' AS link,
+    CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END AS link,
     '/footer-links.js' AS javascript,
     '**CMS Latest Dataset and Resources (2023)**  
     - [Medicare Physician & Other Practitioners - by Provider](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-provider)  
     - [Medicare Physician & Other Practitioners - by Geography and Service](https://data.cms.gov/provider-summary-by-type-of-service/medicare-physician-other-practitioners/medicare-physician-other-practitioners-by-geography-and-service)' AS footer,
-       '{"link":"/","title":"Home"}' AS menu_item,
+    '{"link":"' || CASE WHEN instr(sqlpage.path(), 'mmi/') > 0 THEN '../' ELSE './' END || '","title":"Home"}' AS menu_item,
        '{"link":"/mmi/executive-dashboard.sql","title":"Executive Dashboard"}' AS menu_item,
        '{"link":"/mmi/opportunity-scoring.sql","title":"Opportunity Scores"}' AS menu_item,
        '{"link":"/mmi/sleep-apnea-evidence.sql","title":"Evidence"}' AS menu_item,
@@ -2001,7 +2001,7 @@ SELECT 'shell' AS component,
        '{"link":"/mmi/data-dictionary.sql","title":"Data Dictionary"}' AS menu_item;
 
 SELECT 'button' AS component, 'start' AS justify;
-SELECT 'Back' AS title, '/' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
+SELECT 'Back' AS title, '../' AS link, 'chevron-left' AS icon, 'outline-secondary' AS outline;
 
 SELECT 'hero' AS component,
     'Data Dictionary & Pipeline Reference' AS title,


### PR DESCRIPTION
This pull request updates the navigation logic and cleans up reference text in the `mmi-dashboard.md` file. The main focus is to ensure that navigation links (such as Home and Back) correctly adjust their paths depending on the current page context, and to remove inline reference notes from section headers for a cleaner UI.

Key changes include:

Navigation improvements:
- Updated all instances where the navigation `link` and `menu_item` for "Home" are set, so they dynamically use `'../'` if the current path contains `'mmi/'`, otherwise `'./'`. This ensures correct relative navigation from both top-level and subdirectory pages. [[1]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL48-R53) [[2]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL75-R80) [[3]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL198-R203) [[4]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL310-R315) [[5]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL382-R387) [[6]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL454-R459) [[7]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL549-R554) [[8]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL618-R623) [[9]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL735-R740) [[10]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL1990-R1995)
- Changed all "Back" button links to use `'../'` instead of `'/'`, so users are taken to the parent directory rather than the site root. [[1]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL212-R212) [[2]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL324-R324) [[3]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL468-R468) [[4]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL563-R563) [[5]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL632-R632) [[6]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL749-R757)

UI and content cleanup:
- Removed inline reference notes from section headers (the `contents` field in `SELECT 'text' AS component`) throughout the dashboard, so these sections now display without reference details, resulting in a cleaner interface. [[1]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL749-R757) [[2]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL857-R857) [[3]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL978-R978) [[4]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL1066-R1066) [[5]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL1242-R1242) [[6]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL1332-R1332) [[7]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL1554-R1554) [[8]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL1650-R1650) [[9]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eL1871-R1871)