### PR TITLE
feat: remove unused columns and sorting logic from chronic interactio…

### DIFF
--- a/mmi-dashboard.md
+++ b/mmi-dashboard.md
@@ -506,16 +506,16 @@ SELECT
     specialty_name      AS "Specialty",
     hcpcs_code          AS "HCPCS",
     procedure_description AS "Procedure",
-    procedure_category  AS "Category",
-    total_benes         AS "Patients",
-    interaction_tier    AS "Interaction Tier"
+    -- procedure_category  AS "Category",  -- Removed because not present in view
+    total_benes         AS "Patients"
+    -- interaction_tier    AS "Interaction Tier"
 FROM chronic_interaction_density
 ORDER BY
-    CASE interaction_tier
-        WHEN 'High (12+ sessions/yr)' THEN 1
-        WHEN 'Moderate (4-11 sessions/yr)' THEN 2
-        ELSE 3
-    END,
+    -- CASE interaction_tier
+    --     WHEN 'High (12+ sessions/yr)' THEN 1
+    --     WHEN 'Moderate (4-11 sessions/yr)' THEN 2
+    --     ELSE 3
+    -- END,
     total_benes DESC
 LIMIT 50;
 


### PR DESCRIPTION
This pull request makes minor adjustments to the SQL `SELECT` statement in `mmi-dashboard.md` to align the query with the current schema of the `chronic_interaction_density` view. Specifically, it removes references to columns that are no longer present.

- Removed `procedure_category` and `interaction_tier` columns from the `SELECT` list, as they are not present in the view.
- Commented out the `ORDER BY interaction_tier` logic since the column is unavailable.…n density query