### PR TITLE
Update registration page title and add server-side redirect

### DIFF
--- a/mmi-dashboard.md
+++ b/mmi-dashboard.md
@@ -70,7 +70,7 @@ SELECT 'cookie' AS component,
 WHERE COALESCE(sqlpage.cookie('isVerified'), '') = '';
 
 SELECT 'shell' AS component,
-       'Medigy Market Intelligence — Registration' AS title,
+       'Medigy Market Intelligence' AS title,
        NULL AS icon,
        'narrow' AS layout,
        true AS fixed_top_menu,

--- a/mmi-dashboard.md
+++ b/mmi-dashboard.md
@@ -62,6 +62,14 @@ SELECT 'shell' AS component,
 ```sql index.sql { route: { caption: "Registration" } }
 -- @route.description "User registration gate before entering the dashboard"
 
+-- Early server-side redirect: if the registration profile cookie is already present,
+-- skip the form immediately — this prevents the shell/hero/form from being rendered
+-- and sent to the browser, eliminating the flicker that occurred when the JS redirect
+-- in footer-links.js fired after the page was already painted.
+SELECT 'redirect' AS component,
+       '/mmi/home-overview.sql' AS link
+WHERE COALESCE(sqlpage.cookie('medigy_mmi_registration_profile_v2'), '') != '';
+
 SELECT 'cookie' AS component,
        'isVerified' AS name,
        'false' AS value,
@@ -312,6 +320,11 @@ WHERE $email_is_valid = 1 AND $phone_is_valid = 1 AND $consent_is_valid = 1;
 
 ```sql registration.sql { route: { caption: "Registration Alias" } }
 -- @route.description "Alias route for user registration gate"
+
+-- Early server-side redirect: mirrors the same guard in index.sql.
+SELECT 'redirect' AS component,
+       '/mmi/home-overview.sql' AS link
+WHERE COALESCE(sqlpage.cookie('medigy_mmi_registration_profile_v2'), '') != '';
 
 SELECT 'cookie' AS component,
        'isVerified' AS name,


### PR DESCRIPTION
This pull request improves the user registration flow in the dashboard by introducing an early server-side redirect for users who have already completed registration. This prevents unnecessary rendering of the registration form and eliminates the visual flicker caused by the previous client-side redirect. Additionally, the registration page title is simplified.

Redirect logic improvements:

* Added a server-side redirect at the start of both `index.sql` and `registration.sql` to immediately send users with the `medigy_mmi_registration_profile_v2` cookie to `/mmi/home-overview.sql`, preventing the registration form from rendering and eliminating UI flicker. [[1]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eR65-R72) [[2]](diffhunk://#diff-4e36ef2a9ffe85a1ad430d43078c88c18d3774cf7102d4f42a827235d7a8442eR324-R328)

UI/UX adjustments:

* Updated the registration page title in the `shell` component from `'Medigy Market Intelligence — Registration'` to `'Medigy Market Intelligence'` for a cleaner appearance.